### PR TITLE
Pr gps ev announce

### DIFF
--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.cpp
@@ -272,9 +272,10 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 		}
 	}
 
-	// If GPS aiding is required, declare fault condition if the required GPS quality checks are failing
-	if (_param_sys_has_gps.get()) {
+		// If GPS aiding is required, declare fault condition if the required GPS quality checks are failing
+		if (_param_sys_has_gps.get()) {
 		const bool ekf_gps_fusion = estimator_status.control_mode_flags & (1 << estimator_status_s::CS_GPS);
+		const bool ekf_ev_fusion = estimator_status.control_mode_flags & (1 << estimator_status_s::CS_EV_POS);
 		const bool ekf_gps_check_fail = estimator_status.gps_check_fail_flags > 0;
 
 		if (ekf_gps_fusion) {
@@ -284,25 +285,44 @@ void EstimatorChecks::checkEstimatorStatus(const Context &context, Report &repor
 		if (context.isArmed()) {
 
 			if (_gps_was_fused && !ekf_gps_fusion) {
-				if (reporter.mavlink_log_pub()) {
-					mavlink_log_warning(reporter.mavlink_log_pub(), "GNSS data fusion stopped\t");
-				}
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_warning(reporter.mavlink_log_pub(), "GNSS data fusion stopped\t");
+			}
 
-				events::send(events::ID("check_estimator_gnss_fusion_stopped"), {events::Log::Error, events::LogInternal::Info},
-					     "GNSS data fusion stopped");
+			events::send(events::ID("check_estimator_gnss_fusion_stopped"), {events::Log::Error, events::LogInternal::Info},
+					"GNSS data fusion stopped");
 
 			} else if (!_gps_was_fused && ekf_gps_fusion) {
 
-				if (reporter.mavlink_log_pub()) {
-					mavlink_log_info(reporter.mavlink_log_pub(), "GNSS data fusion started\t");
-				}
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_info(reporter.mavlink_log_pub(), "GNSS data fusion started\t");
+			}
 
-				events::send(events::ID("check_estimator_gnss_fusion_started"), {events::Log::Info, events::LogInternal::Info},
-					     "GNSS data fusion started");
+			events::send(events::ID("check_estimator_gnss_fusion_started"), {events::Log::Info, events::LogInternal::Info},
+					"GNSS data fusion started");
+			}
+
+			if (_ev_was_fused && !ekf_ev_fusion) {
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_warning(reporter.mavlink_log_pub(), "EV data fusion stopped\t");
+			}
+
+			events::send(events::ID("check_estimator_ev_fusion_stopped"), {events::Log::Error, events::LogInternal::Info},
+					"EV data fusion stopped");
+
+			} else if (!_ev_was_fused && ekf_ev_fusion) {
+
+			if (reporter.mavlink_log_pub()) {
+				mavlink_log_info(reporter.mavlink_log_pub(), "EV data fusion started\t");
+			}
+
+			events::send(events::ID("check_estimator_ev_fusion_started"), {events::Log::Info, events::LogInternal::Info},
+					"EV data fusion started");
 			}
 		}
 
 		_gps_was_fused = ekf_gps_fusion;
+		_ev_was_fused = ekf_ev_fusion;
 
 		if (!context.isArmed() && ekf_gps_check_fail) {
 			NavModes required_groups_gps = required_groups;

--- a/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
+++ b/src/modules/commander/HealthAndArmingChecks/checks/estimatorCheck.hpp
@@ -102,6 +102,7 @@ private:
 	bool _position_reliant_on_optical_flow{false};
 
 	bool _gps_was_fused{false};
+	bool _ev_was_fused{false};
 
 	DEFINE_PARAMETERS_CUSTOM_PARENT(HealthAndArmingCheckBase,
 					(ParamInt<px4::params::SYS_MC_EST_GROUP>) _param_sys_mc_est_group,


### PR DESCRIPTION

### Solved Problem


### Solution

The solution extends the PX4 code snippet to announce the start or stop of EV fusion. It adds additional conditions and log messages to check the state of the ekf_ev_fusion flag and triggers appropriate announcements.

### Changelog Entry

For release notes:
```
Feature: Extended PX4 code snippet to announce EV fusion start/stop
New parameter: N/A
Documentation: N/A
```

### Alternatives

An alternative approach could have been to modify the existing log messages or events to include both GNSS and EV fusion information in a single announcement. However, the chosen solution keeps the announcements separate for clarity.

### Test coverage

Unit/integration test: @farhangnaderi will do it.

Simulation/hardware testing logs: https://review.px4.io/plot_app?log=2fc71b57-b9c6-4458-858a-2e97a211b084

### Context

N/A
